### PR TITLE
Make redirects permanent

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,3 +5,4 @@ Changelog
 -------------------
 
 - Initial release
+- Make redirects permanent [instification]

--- a/pretaweb/redirect/redirect.py
+++ b/pretaweb/redirect/redirect.py
@@ -156,7 +156,7 @@ class Redirector(ObjectManager):
         path = '/'.join(request['traverse_subpath'])
         url = self.redirect(domain, path, request['QUERY_STRING'])
         if url:
-            request.response.redirect(url)
+            request.response.redirect(url, status="301")
         else:
             request.response.setStatus(404, "Not Found")
 


### PR DESCRIPTION
Currently uses the default `request.response.redirect()` call which issues a 302 temporary redirect. The nature of this package is to provide a more permanent configurable solution with the typical usecase being non-www -> www which would be best suited as a 301 (permanent).

Ideally it would be configurable in the config with 301 as the default, but setting a sane default is a good first step imo